### PR TITLE
bitbots_bringup: adds torqueless_mode launch param for motion

### DIFF
--- a/bitbots_bringup/launch/motion.launch
+++ b/bitbots_bringup/launch/motion.launch
@@ -3,6 +3,8 @@
     <arg name="walking" default="true" doc="start the walking" />
     <arg name="use_game_settings" default="false"/>
     <arg name="dynamic_kick" default="true" />
+    <arg name="torqueless_mode" default="false" />
+
 
     <rosparam param="actionlib_client_sub_queue_size">-1</rosparam>
     <rosparam param="actionlib_server_sub_queue_size">-1</rosparam>
@@ -14,6 +16,8 @@
     <group unless="$(arg sim)">
         <include file="$(find bitbots_ros_control)/launch/ros_control.launch">
             <arg name="use_game_settings" value="$(arg use_game_settings)"/>
+            <arg name="torqueless_mode" value="$(arg torqueless_mode)" />
+
         </include>
         <!--<include file="$(find bitbots_odometry)/launch/odometry_fuser.launch" />-->
         <node name="set_volume" pkg="bitbots_bringup" type="set_volume.sh" args="100%" />

--- a/bitbots_bringup/launch/motion_standalone.launch
+++ b/bitbots_bringup/launch/motion_standalone.launch
@@ -1,15 +1,19 @@
 <launch>
     <arg name="sim" default="false"/>
+    <arg name="torqueless_mode" default="false" />
+
     <!-- defines camera type -->
     <arg name="basler" default="true" doc="Defines the robot camera type"/>
 
     <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">
         <arg name="sim" value="$(arg sim)"/>
-        <arg name="basler" value="$(arg basler)"/>           
+        <arg name="basler" value="$(arg basler)"/>
     </include>    
 
     <include file="$(find bitbots_bringup)/launch/motion.launch">
-        <arg name="sim" value="$(arg sim)"/>         
+        <arg name="sim" value="$(arg sim)"/>
+        <arg name="torqueless_mode" value="$(arg torqueless_mode)" />
+
     </include>
 
 </launch>


### PR DESCRIPTION
This PR adds a `torqueless_mode` launch parameter for the motion launch.
Closes bit-bots/bitbots_motion#74.