### PR TITLE
Add a remote launch script and a vision reference implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,9 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# auto-generated documentation
+**/doc
+**/docs/_build
+**/docs/_out
+**/docs/conf.py

--- a/bitbots_bringup/launch/highlevel.launch
+++ b/bitbots_bringup/launch/highlevel.launch
@@ -10,7 +10,7 @@
     <arg name="gamecontroller" default="true" doc="Sets whether the Gamecontroller should be started"/>
 
     <arg name="use_game_settings" default="true"/>
-    
+
     <arg name="sim_ns" default="/" />
 
     <group if="$(arg gamecontroller)">
@@ -20,9 +20,8 @@
     </group>
 
     <group if="$(arg vision)">
-        <include file="$(find bitbots_vision)/launch/vision_startup.launch">
+        <include file="$(find bitbots_bringup)/launch/remote_vision.launch">
             <arg name="sim" value="$(arg sim)" />
-            <arg name="debug" value="true" />
             <arg name="basler" value="$(arg basler)" />
             <arg name="use_game_settings" value="$(arg use_game_settings)"/>
         </include>

--- a/bitbots_bringup/launch/highlevel.launch
+++ b/bitbots_bringup/launch/highlevel.launch
@@ -2,7 +2,7 @@
     <arg name="sim" default="false"/>
     <arg name="motion" default="true"/>
     <arg name="behave" default="true"/>
-    <arg name="vision" default="false"/>
+    <arg name="vision" default="true"/>
     <arg name="teamcom" default="false"/>
     <arg name="localization" default="false"/>
     <arg name="simple" default="false" doc="Whether to use the simple behavior" />

--- a/bitbots_bringup/launch/remote_vision.launch
+++ b/bitbots_bringup/launch/remote_vision.launch
@@ -5,11 +5,13 @@
   <arg name="basler" default="true" doc="true: launches the basler camera driver instead of the wolves image provider" />
   <arg name="dummyball" default="false" doc="true: does not start the ball detection to save resources" />
   <arg name="debug" default="false" doc="true: activates publishing of several debug images" />
+  <arg name="device" default="jetson" doc="name of the device the vision should be launched on" />
+  <arg name="host" default="nuc" doc="name of the ros master" />
   <arg name="use_game_settings" default="false" doc="true: loads additional game settings" />
 
   <node pkg="bitbots_bringup" type="launch_on_remote.sh"
-    args="jetson
-          nuc
+    args="$(arg device)
+          $(arg host)
           bitbots_vision
           vision_startup.launch
           sim:=$(arg sim)

--- a/bitbots_bringup/launch/remote_vision.launch
+++ b/bitbots_bringup/launch/remote_vision.launch
@@ -1,7 +1,23 @@
 <launch>
+  <!-- Launch the vision on a remote device-->
+  <arg name="sim" default="false" doc="true: activates simulation time, switches to simulation color settings and deactivates launching of an image provider" />
+  <arg name="camera" default="true" doc="true: launches an image provider to get images from a camera (unless sim:=true)" />
+  <arg name="basler" default="true" doc="true: launches the basler camera driver instead of the wolves image provider" />
+  <arg name="dummyball" default="false" doc="true: does not start the ball detection to save resources" />
+  <arg name="debug" default="false" doc="true: activates publishing of several debug images" />
+  <arg name="use_game_settings" default="false" doc="true: loads additional game settings" />
+
   <node pkg="bitbots_bringup" type="launch_on_remote.sh"
-    <!-- args: PACKAGE_NAME LAUNCHFILE LAUNCHHARGS-->
-    args=""
-    name="vision_jetson_launch" output="screen">
+    args="jetson
+          nuc
+          bitbots_vision
+          vision_startup.launch
+          sim:=$(arg sim)
+          camera:=$(arg camera)
+          basler:=$(arg basler)
+          dummyball:=$(arg dummyball)
+          debug:=$(arg debug)
+          use_game_settings:=$(arg use_game_settings)"
+    name="vision_jetson_remote" output="screen">
   </node>
 </launch>

--- a/bitbots_bringup/launch/remote_vision.launch
+++ b/bitbots_bringup/launch/remote_vision.launch
@@ -1,0 +1,7 @@
+<launch>
+  <node pkg="bitbots_bringup" type="launch_on_remote.sh"
+    <!-- args: PACKAGE_NAME LAUNCHFILE LAUNCHHARGS-->
+    args=""
+    name="vision_jetson_launch" output="screen">
+  </node>
+</launch>

--- a/bitbots_bringup/launch/teamplayer.launch
+++ b/bitbots_bringup/launch/teamplayer.launch
@@ -2,7 +2,7 @@
     <arg name="sim" default="false"/>
     <arg name="motion" default="true"/>
     <arg name="behave" default="true"/>
-    <arg name="vision" default="false"/>
+    <arg name="vision" default="true"/>
     <arg name="teamcom" default="false"/>
     <arg name="localization" default="false"/>
     <arg name="simple" default="false"/>  <!-- whether to use the simple behavior -->
@@ -12,7 +12,7 @@
     <arg name="gamecontroller" default="true" doc="Sets whether the Gamecontroller should be started"/>
 
     <arg name="use_game_settings" default="true"/>
-    
+
     <arg name="sim_ns" default="/" />
 
     <group unless="$(arg gazebo)">

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -5,7 +5,7 @@
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 
-  <maintainer email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</maintainer>
+  <maintainer email="7sell@informatik.uni-hamburg.de">Finn-Thorben Sell</maintainer>
   <maintainer email="info@bit-bots.de">Hamburg Bit-Bots</maintainer>
   <author email="info@bit-bots.de">Hamburg Bit-Bots</author>
   <license>MIT</license>

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -9,4 +9,4 @@
 # 4 param is the launch file
 # Following params are the roslaunch arguments
 
-ssh -t -t $1 'export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:3}'"'
+ssh -t -t $1 'source ~/.zshrc; export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "echo '${@:3}'"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+##########
+# Params #
+##########
 # 1 param is the remote device
 # 2 param is the ros master
 # 3 param is the ros_package

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -9,4 +9,4 @@
 # 4 param is the launch file
 # Following params are the roslaunch arguments
 
-ssh -t -t $1 'export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:2}'"'
+ssh -t -t $1 'export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:3}'"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-ssh -t -t jetson 'export ROS_MASTER_URI=http://nuc:11311/; zsh -o HUP -c "roslaunch bitbots_vision vision_startup.launch debug:=true"'
+# 1 param is the remote device
+# 2 param is the ros master
+# 3 param is the ros_package
+# 4 param is the launch file
+# Following params are the roslaunch arguments
+
+ssh -t -t $0 'export ROS_MASTER_URI=http://$1:11311/; zsh -o HUP -c "roslaunch ${@:2}"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ssh -t -t jetson 'export ROS_MASTER_URI=http://nuc:11311/; zsh -o HUP -c "roslaunch bitbots_vision vision_startup.launch debug:=true"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -9,4 +9,4 @@
 # 4 param is the launch file
 # Following params are the roslaunch arguments
 
-ssh -t -t $1 'source ~/.zshrc; export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "echo '${@:3}'"'
+ssh -t -t $1 'source ~/.zshrc; export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:3}'"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -9,4 +9,4 @@
 # 4 param is the launch file
 # Following params are the roslaunch arguments
 
-ssh -t -t $1 'source ~/.zshrc; export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:3}'"'
+ssh -t -t $1 'source ~/.zshrc; export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${*:3}'"'

--- a/bitbots_bringup/scripts/launch_on_remote.sh
+++ b/bitbots_bringup/scripts/launch_on_remote.sh
@@ -9,4 +9,4 @@
 # 4 param is the launch file
 # Following params are the roslaunch arguments
 
-ssh -t -t $0 'export ROS_MASTER_URI=http://$1:11311/; zsh -o HUP -c "roslaunch ${@:2}"'
+ssh -t -t $1 'export ROS_MASTER_URI=http://'$2':11311/; zsh -o HUP -c "roslaunch '${@:2}'"'


### PR DESCRIPTION
This adds the possibility to launch launch files on another machine out of a launch file.
It includes also a demo implementation using the vision launch on the jetson.