### PR TITLE
add new package convenience frames

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 @Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
 
 bitbotsPipeline([
-	new PackageDefinition("bitbots_bringup", true)
+	new PackageDefinition("bitbots_bringup", true),
+	new PackageDefinition("bitbots_convenience_frames", true)
 ] as PackageDefinition[])

--- a/bitbots_bringup/launch/load_robot_description.launch
+++ b/bitbots_bringup/launch/load_robot_description.launch
@@ -76,4 +76,5 @@
 
     <include file="$(find humanoid_base_footprint)/launch/base_footprint.launch"/>
     <include file="$(find bitbots_odometry)/launch/odometry.launch"/>
+    <include file="$(find bitbots_convenience_frames)/launch/convenience_frames.launch"/>
 </launch>

--- a/bitbots_convenience_frames/CMakeLists.txt
+++ b/bitbots_convenience_frames/CMakeLists.txt
@@ -24,6 +24,6 @@ include_directories(
 add_executable(convenience_frames src/convenience_frames.cpp)
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(base_footprint
+target_link_libraries(convenience_frames
     ${catkin_LIBRARIES}
 )

--- a/bitbots_convenience_frames/CMakeLists.txt
+++ b/bitbots_convenience_frames/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_convenience_frames)
 
 find_package(catkin REQUIRED COMPONENTS
+  bitbots_docs
   roscpp
   std_msgs
   tf2
@@ -26,3 +27,5 @@ add_executable(convenience_frames src/convenience_frames.cpp)
 target_link_libraries(convenience_frames
     ${catkin_LIBRARIES}
 )
+
+enable_bitbots_docs()

--- a/bitbots_convenience_frames/CMakeLists.txt
+++ b/bitbots_convenience_frames/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(bitbots_convenience_frames)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rosconsole
+  std_msgs
+  sensor_msgs
+  tf2
+  tf2_geometry_msgs
+  tf_conversions
+  message_generation
+  geometry_msgs
+  rospy
+)
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ executable
+add_executable(convenience_frames src/convenience_frames.cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(base_footprint
+    ${catkin_LIBRARIES}
+)

--- a/bitbots_convenience_frames/CMakeLists.txt
+++ b/bitbots_convenience_frames/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   geometry_msgs
   rospy
+  humanoid_league_msgs
 )
 
 catkin_package()

--- a/bitbots_convenience_frames/CMakeLists.txt
+++ b/bitbots_convenience_frames/CMakeLists.txt
@@ -3,13 +3,10 @@ project(bitbots_convenience_frames)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  rosconsole
   std_msgs
-  sensor_msgs
   tf2
   tf2_geometry_msgs
-  tf_conversions
-  message_generation
+  tf2_ros
   geometry_msgs
   rospy
   humanoid_league_msgs
@@ -19,6 +16,7 @@ catkin_package()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  include
 )
 
 ## Declare a C++ executable

--- a/bitbots_convenience_frames/include/bitbots_convenience_frames/convenience_frames.h
+++ b/bitbots_convenience_frames/include/bitbots_convenience_frames/convenience_frames.h
@@ -1,0 +1,28 @@
+#include <ros/ros.h>
+#include <std_msgs/Char.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/utils.h>
+#include <humanoid_league_msgs/BallRelative.h>
+#include <humanoid_league_msgs/GoalRelative.h>
+#include <humanoid_league_msgs/GoalPartsRelative.h>
+
+#include <utility>
+
+class ConvenienceFramesBroadcaster {
+ public:
+  ConvenienceFramesBroadcaster();
+ private:
+  tf2_ros::TransformBroadcaster broadcaster_{tf2_ros::TransformBroadcaster()};
+  geometry_msgs::TransformStamped tf_{geometry_msgs::TransformStamped()};
+  tf2_ros::Buffer tfBuffer_{ros::Duration(1.0)};
+  tf2_ros::TransformListener tfListener_{tfBuffer_};
+  bool is_left_support{false};
+  bool got_support_foot_{false};
+  void publishTransform(std::string header_frame_id, std::string child_frame_id, double x, double y, double z);
+  void supportFootCallback(const std_msgs::Char::ConstPtr &msg);
+  void ballCallback(const humanoid_league_msgs::BallRelative::ConstPtr &msg);
+  void goalCallback(const humanoid_league_msgs::GoalRelative::ConstPtr &msg);
+  void goalPartsCallback(const humanoid_league_msgs::GoalPartsRelative::ConstPtr &msg);
+};

--- a/bitbots_convenience_frames/launch/convenience_frames.launch
+++ b/bitbots_convenience_frames/launch/convenience_frames.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node pkg="bitbots_convenience_frames" type="convenience_frames" name="convenience_frames" />
+
+</launch>

--- a/bitbots_convenience_frames/package.xml
+++ b/bitbots_convenience_frames/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>bitbots_convenience_frames</name>
+  <version>1.0.0</version>
+  <description>Publishes convenience frames for the Hamburg-BitBots code base.</description>
+
+  <maintainer email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</maintainer>
+  <maintainer email="info@bit-bots.de">Hamburg Bit-Bots</maintainer>
+  <author email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</author>
+
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>rospy</depend>
+  <depend>roscpp</depend>
+  <depend>rosconsole</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf_conversions</depend>
+  <depend>geometry_msgs</depend>
+  <depend>message_generation</depend>
+
+  <export>
+    <bitbots_documentation>
+      <language>python2</language>
+      <status>tested_integration</status>
+    </bitbots_documentation>
+    <rosdoc config="rosdoc.yaml"/>
+  </export>
+</package>

--- a/bitbots_convenience_frames/package.xml
+++ b/bitbots_convenience_frames/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>bitbots_docs</depend>
   <depend>rospy</depend>
   <depend>roscpp</depend>
   <depend>std_msgs</depend>

--- a/bitbots_convenience_frames/package.xml
+++ b/bitbots_convenience_frames/package.xml
@@ -14,19 +14,17 @@
 
   <depend>rospy</depend>
   <depend>roscpp</depend>
-  <depend>rosconsole</depend>
   <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tf_conversions</depend>
+  <depend>tf2_ros</depend>
   <depend>geometry_msgs</depend>
-  <depend>message_generation</depend>
+  <depend>humanoid_league_msgs</depend>
 
   <export>
     <bitbots_documentation>
       <language>c++</language>
-      <status>compiles</status>
+      <status>tested_robot</status>
     </bitbots_documentation>
     <rosdoc config="rosdoc.yaml"/>
   </export>

--- a/bitbots_convenience_frames/package.xml
+++ b/bitbots_convenience_frames/package.xml
@@ -25,8 +25,8 @@
 
   <export>
     <bitbots_documentation>
-      <language>python2</language>
-      <status>tested_integration</status>
+      <language>c++</language>
+      <status>compiles</status>
     </bitbots_documentation>
     <rosdoc config="rosdoc.yaml"/>
   </export>

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -20,7 +20,7 @@ private:
     void supportFootCallback(const std_msgs::Char msg);
 };
 
-ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Duration(10.0)),  tfListener(tfBuffer)
+ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Duration(1.0)),  tfListener(tfBuffer)
 {
     //setup tf listener and broadcaster as class members
     
@@ -36,15 +36,15 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Dur
     while(ros::ok())
     {
         ros::spinOnce();
-        geometry_msgs::TransformStamped tf_right, 
+        geometry_msgs::TransformStamped tf_right, // right foot in baselink frame
                                         tf_left,
-                                        tf_right_toe,
+                                        tf_right_toe, // right toes baselink frame
                                         tf_left_toe,
-                                        support_foot, 
+                                        support_foot, // support foot in baselink frame
                                         non_support_foot, 
                                         non_support_foot_in_support_foot_frame, 
                                         base_footprint_in_support_foot_frame,
-                                        front_foot,
+                                        front_foot, // foot that is currently in front of the other, in baselink frame
                                         back_foot;
 
         try{
@@ -101,7 +101,7 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Dur
             geometry_msgs::PoseStamped approach_frame;
             // x at front foot toes
             approach_frame.pose.position.x = front_foot.transform.translation.x;
-            // y between foots
+            // y between feet
             tf2::Transform center_between_foot;
             double y = non_support_foot_in_support_foot_frame.transform.translation.y / 2;
             center_between_foot.setOrigin({0.0, y, 0.0});
@@ -137,7 +137,6 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Dur
             br.sendTransform(tf);
 
         } catch(...){
-            //ROS_WARN_THROTTLE(2, "Can not publish base_footprint, check your tf tree");
             continue;
         }
 

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -37,7 +37,7 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
                                                                      ros::TransportHints().tcpNoDelay());
 
   static tf2_ros::TransformBroadcaster br;
-  ros::Rate r(100.0);
+  ros::Rate r(200.0);
   while (ros::ok()) {
     ros::spinOnce();
     geometry_msgs::TransformStamped tf_right, // right foot in baselink frame
@@ -121,7 +121,7 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
 
       // pitch and roll from support foot, yaw from base link
       tf2::Quaternion rotation;
-      rotation.setRPY(0.0, 0.0, yaw);
+      rotation.setRPY(roll, pitch, yaw);
       approach_frame.pose.orientation = tf2::toMsg(rotation);
 
       // set the broadcasted transform to the position and orientation of the base footprint
@@ -133,11 +133,9 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
       tf.transform.translation.z = approach_frame.pose.position.z;
       tf.transform.rotation = approach_frame.pose.orientation;
       br.sendTransform(tf);
-
     } catch (...) {
       continue;
     }
-
     r.sleep();
   }
 }
@@ -149,7 +147,6 @@ void ConvenienceFramesBroadcaster::supportFootCallback(const std_msgs::Char::Con
 
 int main(int argc, char **argv) {
   ros::init(argc, argv, "convenience_frames");
-
   ConvenienceFramesBroadcaster b;
 }
 

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -14,7 +14,7 @@ class ConvenienceFramesBroadcaster {
  public:
   ConvenienceFramesBroadcaster();
  private:
-  tf2_ros::TransformBroadcaster broadcaster_;
+  tf2_ros::TransformBroadcaster broadcaster_{tf2_ros::TransformBroadcaster()};
   geometry_msgs::TransformStamped tf_{geometry_msgs::TransformStamped()};
   tf2_ros::Buffer tfBuffer_{ros::Duration(1.0)};
   tf2_ros::TransformListener tfListener_{tfBuffer_};

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -15,10 +15,11 @@ class ConvenienceFramesBroadcaster {
   ConvenienceFramesBroadcaster();
  private:
   tf2_ros::TransformBroadcaster broadcaster_;
-  geometry_msgs::TransformStamped tf_;
-  tf2_ros::Buffer tfBuffer_;
-  tf2_ros::TransformListener tfListener_;
-  bool is_left_support, got_support_foot_;
+  geometry_msgs::TransformStamped tf_{geometry_msgs::TransformStamped()};
+  tf2_ros::Buffer tfBuffer_{ros::Duration(1.0)};
+  tf2_ros::TransformListener tfListener_{tfBuffer_};
+  bool is_left_support{false};
+  bool got_support_foot_{false};
   void publishTransform(std::string header_frame_id, std::string child_frame_id, double x, double y, double z);
   void supportFootCallback(const std_msgs::Char::ConstPtr &msg);
   void ballCallback(const humanoid_league_msgs::BallRelative::ConstPtr &msg);
@@ -26,12 +27,7 @@ class ConvenienceFramesBroadcaster {
   void goalPartsCallback(const humanoid_league_msgs::GoalPartsRelative::ConstPtr &msg);
 };
 
-ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
-    : tfBuffer_(ros::Duration(1.0)),
-      tfListener_(tfBuffer_),
-      is_left_support(false),
-      tf_(geometry_msgs::TransformStamped()),
-      broadcaster_() {
+ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() {
   ros::NodeHandle n("~");
   got_support_foot_ = false;
   ros::Subscriber walking_support_foot_subscriber = n.subscribe("/walk_support_state",

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -1,31 +1,4 @@
-#include <ros/ros.h>
-#include <std_msgs/Char.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2/utils.h>
-#include <humanoid_league_msgs/BallRelative.h>
-#include <humanoid_league_msgs/GoalRelative.h>
-#include <humanoid_league_msgs/GoalPartsRelative.h>
-
-#include <utility>
-
-class ConvenienceFramesBroadcaster {
- public:
-  ConvenienceFramesBroadcaster();
- private:
-  tf2_ros::TransformBroadcaster broadcaster_{tf2_ros::TransformBroadcaster()};
-  geometry_msgs::TransformStamped tf_{geometry_msgs::TransformStamped()};
-  tf2_ros::Buffer tfBuffer_{ros::Duration(1.0)};
-  tf2_ros::TransformListener tfListener_{tfBuffer_};
-  bool is_left_support{false};
-  bool got_support_foot_{false};
-  void publishTransform(std::string header_frame_id, std::string child_frame_id, double x, double y, double z);
-  void supportFootCallback(const std_msgs::Char::ConstPtr &msg);
-  void ballCallback(const humanoid_league_msgs::BallRelative::ConstPtr &msg);
-  void goalCallback(const humanoid_league_msgs::GoalRelative::ConstPtr &msg);
-  void goalPartsCallback(const humanoid_league_msgs::GoalPartsRelative::ConstPtr &msg);
-};
+#include<bitbots_convenience_frames/convenience_frames.h>
 
 ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() {
   ros::NodeHandle n("~");

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -1,7 +1,5 @@
 #include <ros/ros.h>
-#include <sensor_msgs/Imu.h>
 #include <std_msgs/Char.h>
-#include <std_msgs/Time.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -48,8 +46,7 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
         non_support_foot,
         non_support_foot_in_support_foot_frame,
         base_footprint_in_support_foot_frame,
-        front_foot, // foot that is currently in front of the other, in baselink frame
-        back_foot;
+        front_foot; // foot that is currently in front of the other, in baselink frame
 
     try {
       tf_right = tfBuffer.lookupTransform("base_link", "r_sole", ros::Time::now(), ros::Duration(0.1));
@@ -80,10 +77,8 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
       // check with foot is in front
       if (tf_right.transform.translation.x < tf_left.transform.translation.x) {
         front_foot = tf_left_toe;
-        back_foot = tf_right_toe;
       } else {
         front_foot = tf_right_toe;
-        back_foot = tf_left_toe;
       }
 
       // get the position of the non support foot in the support frame, used for computing the barycenter

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -1,0 +1,145 @@
+#include <ros/ros.h>
+#include <sensor_msgs/Imu.h>
+#include <std_msgs/Char.h>
+#include <std_msgs/Time.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2/utils.h>
+
+
+class ConvenienceFramesBroadcaster
+{
+public:
+    ConvenienceFramesBroadcaster();
+private:
+    geometry_msgs::TransformStamped tf;
+    tf2_ros::Buffer tfBuffer;
+    tf2_ros::TransformListener tfListener;
+    bool is_left_support, got_support_foot;
+    void supportFootCallback(const std_msgs::Char msg);
+};
+
+ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Duration(10.0)),  tfListener(tfBuffer)
+{
+    //setup tf listener and broadcaster as class members
+    
+    ros::NodeHandle n("~");
+    got_support_foot = false;
+    ros::Subscriber walking_support_foot_subscriber = n.subscribe("/walk_support_state", 1, &ConvenienceFramesBroadcaster::supportFootCallback, this, ros::TransportHints().tcpNoDelay());
+    ros::Subscriber dynamic_kick_support_foot_subscriber = n.subscribe("/dynamic_kick_support_state", 1, &ConvenienceFramesBroadcaster::supportFootCallback, this, ros::TransportHints().tcpNoDelay());
+
+    tf = geometry_msgs::TransformStamped();
+    
+    static tf2_ros::TransformBroadcaster br;
+    ros::Rate r(30.0);
+    while(ros::ok())
+    {
+        ros::spinOnce();
+        geometry_msgs::TransformStamped tf_right, 
+                                        tf_left, 
+                                        support_foot, 
+                                        non_support_foot, 
+                                        non_support_foot_in_support_foot_frame, 
+                                        base_footprint_in_support_foot_frame,
+                                        front_foot,
+                                        back_foot;
+
+        try{
+            tf_right = tfBuffer.lookupTransform("base_link", "r_sole", ros::Time::now(), ros::Duration(0.1));
+            tf_left = tfBuffer.lookupTransform("base_link", "l_sole",  ros::Time::now(), ros::Duration(0.1));
+
+            // compute support foot
+            if(got_support_foot)
+            {
+                if(is_left_support)
+                {
+                    support_foot = tf_left;
+                    non_support_foot = tf_right;
+                }
+                else
+                {
+                    support_foot = tf_right;
+                    non_support_foot = tf_left;
+                }
+            }
+            else
+            {
+                // check which foot is support foot (which foot is on the ground)
+                if(tf_right.transform.translation.z < tf_left.transform.translation.z) {
+                    support_foot = tf_right;
+                    non_support_foot = tf_left;
+                } else {
+                    support_foot = tf_left;
+                    non_support_foot = tf_right;
+                }
+            }
+
+            // check with foot is in front
+            if(tf_right.transform.translation.x < tf_left.transform.translation.x){
+                front_foot = tf_left;
+                back_foot = tf_right;
+            }else{
+                front_foot = tf_right;
+                back_foot = tf_left;
+            }
+
+            // get the position of the non support foot in the support frame, used for computing the barycenter
+            non_support_foot_in_support_foot_frame = tfBuffer.lookupTransform(support_foot.child_frame_id, 
+                                                                              non_support_foot.child_frame_id,
+                                                                              support_foot.header.stamp,
+                                                                              ros::Duration(0.1));
+
+            geometry_msgs::TransformStamped support_to_base_link = tfBuffer.lookupTransform(support_foot.header.frame_id,  
+                                                                                            support_foot.child_frame_id, 
+                                                                                            support_foot.header.stamp);
+
+            geometry_msgs::PoseStamped approach_frame;
+            // x at front foot toes
+            approach_frame.pose.position.x = front_foot.transform.translation.x;
+            // y between foots
+            approach_frame.pose.position.y = non_support_foot_in_support_foot_frame.transform.translation.y/2;
+            // z at ground leven (support foot height)
+            approach_frame.pose.position.z = support_foot.pose.z;
+
+            // yaw of front foot
+            double yaw;
+            yaw = tf2::getYaw(front_foot.transform.rotation);
+            
+            // pitch and roll from support foot, yaw from base link
+            tf2::Quaternion rotation;
+            rotation.setRPY(0.0,0.0,yaw);
+            approach_frame.pose.orientation = tf2::toMsg(rotation);
+
+            // set the broadcasted transform to the position and orientation of the base footprint
+            tf.header.stamp = ros::Time::now();
+            tf.header.frame_id = "base_link";
+            tf.child_frame_id = "approach_frame";
+            tf.transform.translation.x = approach_frame.pose.position.x;
+            tf.transform.translation.y = approach_frame.pose.position.y;
+            tf.transform.translation.z = approach_frame.pose.position.z;
+            tf.transform.rotation = approach_frame.pose.orientation;
+            br.sendTransform(tf);
+
+        } catch(...){
+            //ROS_WARN_THROTTLE(2, "Can not publish base_footprint, check your tf tree");
+            continue;
+        }
+
+        r.sleep();
+    }
+}
+
+void ConvenienceFramesBroadcaster::supportFootCallback(const std_msgs::Char msg)
+{
+    got_support_foot = true;
+    is_left_support = (msg.data == 'l');
+}
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "convenience_frames");
+
+    ConvenienceFramesBroadcaster b;
+}
+

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -7,153 +7,149 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/utils.h>
 
-
-class ConvenienceFramesBroadcaster
-{
-public:
-    ConvenienceFramesBroadcaster();
-private:
-    geometry_msgs::TransformStamped tf;
-    tf2_ros::Buffer tfBuffer;
-    tf2_ros::TransformListener tfListener;
-    bool is_left_support, got_support_foot;
-    void supportFootCallback(const std_msgs::Char msg);
+class ConvenienceFramesBroadcaster {
+ public:
+  ConvenienceFramesBroadcaster();
+ private:
+  geometry_msgs::TransformStamped tf;
+  tf2_ros::Buffer tfBuffer;
+  tf2_ros::TransformListener tfListener;
+  bool is_left_support, got_support_foot;
+  void supportFootCallback(const std_msgs::Char::ConstPtr &msg);
 };
 
-ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() : tfBuffer(ros::Duration(1.0)),  tfListener(tfBuffer)
-{
-    //setup tf listener and broadcaster as class members
-    
-    ros::NodeHandle n("~");
-    got_support_foot = false;
-    ros::Subscriber walking_support_foot_subscriber = n.subscribe("/walk_support_state", 1, &ConvenienceFramesBroadcaster::supportFootCallback, this, ros::TransportHints().tcpNoDelay());
-    ros::Subscriber dynamic_kick_support_foot_subscriber = n.subscribe("/dynamic_kick_support_state", 1, &ConvenienceFramesBroadcaster::supportFootCallback, this, ros::TransportHints().tcpNoDelay());
+ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster()
+    : tfBuffer(ros::Duration(1.0)),
+      tfListener(tfBuffer),
+      is_left_support(false),
+      tf(geometry_msgs::TransformStamped()) {
+  ros::NodeHandle n("~");
+  got_support_foot = false;
+  ros::Subscriber walking_support_foot_subscriber = n.subscribe("/walk_support_state",
+                                                                1,
+                                                                &ConvenienceFramesBroadcaster::supportFootCallback,
+                                                                this,
+                                                                ros::TransportHints().tcpNoDelay());
+  ros::Subscriber dynamic_kick_support_foot_subscriber = n.subscribe("/dynamic_kick_support_state",
+                                                                     1,
+                                                                     &ConvenienceFramesBroadcaster::supportFootCallback,
+                                                                     this,
+                                                                     ros::TransportHints().tcpNoDelay());
 
-    tf = geometry_msgs::TransformStamped();
-    
-    static tf2_ros::TransformBroadcaster br;
-    ros::Rate r(100.0);
-    while(ros::ok())
-    {
-        ros::spinOnce();
-        geometry_msgs::TransformStamped tf_right, // right foot in baselink frame
-                                        tf_left,
-                                        tf_right_toe, // right toes baselink frame
-                                        tf_left_toe,
-                                        support_foot, // support foot in baselink frame
-                                        non_support_foot, 
-                                        non_support_foot_in_support_foot_frame, 
-                                        base_footprint_in_support_foot_frame,
-                                        front_foot, // foot that is currently in front of the other, in baselink frame
-                                        back_foot;
+  static tf2_ros::TransformBroadcaster br;
+  ros::Rate r(100.0);
+  while (ros::ok()) {
+    ros::spinOnce();
+    geometry_msgs::TransformStamped tf_right, // right foot in baselink frame
+        tf_left,
+        tf_right_toe, // right toes baselink frame
+        tf_left_toe,
+        support_foot, // support foot in baselink frame
+        non_support_foot,
+        non_support_foot_in_support_foot_frame,
+        base_footprint_in_support_foot_frame,
+        front_foot, // foot that is currently in front of the other, in baselink frame
+        back_foot;
 
-        try{
-            tf_right = tfBuffer.lookupTransform("base_link", "r_sole", ros::Time::now(), ros::Duration(0.1));
-            tf_left = tfBuffer.lookupTransform("base_link", "l_sole",  ros::Time::now(), ros::Duration(0.1));
-            tf_right_toe = tfBuffer.lookupTransform("base_link", "r_toe", ros::Time::now(), ros::Duration(0.1));
-            tf_left_toe = tfBuffer.lookupTransform("base_link", "l_toe", ros::Time::now(), ros::Duration(0.1));
+    try {
+      tf_right = tfBuffer.lookupTransform("base_link", "r_sole", ros::Time::now(), ros::Duration(0.1));
+      tf_left = tfBuffer.lookupTransform("base_link", "l_sole", ros::Time::now(), ros::Duration(0.1));
+      tf_right_toe = tfBuffer.lookupTransform("base_link", "r_toe", ros::Time::now(), ros::Duration(0.1));
+      tf_left_toe = tfBuffer.lookupTransform("base_link", "l_toe", ros::Time::now(), ros::Duration(0.1));
 
-            // compute support foot
-            if(got_support_foot)
-            {
-                if(is_left_support)
-                {
-                    support_foot = tf_left;
-                    non_support_foot = tf_right;
-                }
-                else
-                {
-                    support_foot = tf_right;
-                    non_support_foot = tf_left;
-                }
-            }
-            else
-            {
-                // check which foot is support foot (which foot is on the ground)
-                if(tf_right.transform.translation.z < tf_left.transform.translation.z) {
-                    support_foot = tf_right;
-                    non_support_foot = tf_left;
-                } else {
-                    support_foot = tf_left;
-                    non_support_foot = tf_right;
-                }
-            }
-
-            // check with foot is in front
-            if(tf_right.transform.translation.x < tf_left.transform.translation.x){
-                front_foot = tf_left_toe;
-                back_foot = tf_right_toe;
-            }else{
-                front_foot = tf_right_toe;
-                back_foot = tf_left_toe;
-            }
-
-            // get the position of the non support foot in the support frame, used for computing the barycenter
-            non_support_foot_in_support_foot_frame = tfBuffer.lookupTransform(support_foot.child_frame_id, 
-                                                                              non_support_foot.child_frame_id,
-                                                                              support_foot.header.stamp,
-                                                                              ros::Duration(0.1));
-
-            geometry_msgs::TransformStamped support_to_base_link = tfBuffer.lookupTransform(support_foot.header.frame_id,  
-                                                                                            support_foot.child_frame_id, 
-                                                                                            support_foot.header.stamp);
-
-            geometry_msgs::PoseStamped approach_frame;
-            // x at front foot toes
-            approach_frame.pose.position.x = front_foot.transform.translation.x;
-            // y between feet
-            tf2::Transform center_between_foot;
-            double y = non_support_foot_in_support_foot_frame.transform.translation.y / 2;
-            center_between_foot.setOrigin({0.0, y, 0.0});
-            center_between_foot.setRotation({0, 0, 0, 1});
-            tf2::Transform support_foot_tf;
-            tf2::fromMsg(support_foot.transform, support_foot_tf);
-            center_between_foot = support_foot_tf * center_between_foot;
-            approach_frame.pose.position.y = center_between_foot.getOrigin().y();
-            // z at ground leven (support foot height)
-            approach_frame.pose.position.z = support_foot.transform.translation.z;
-
-            // roll and pitch of support foot
-            double roll, pitch, yaw;
-            tf2::Quaternion quat;
-            fromMsg(support_foot.transform.rotation, quat);
-            tf2::Matrix3x3(quat).getRPY(roll, pitch, yaw);
-            // yaw of front foot
-            yaw = tf2::getYaw(front_foot.transform.rotation);
-            
-            // pitch and roll from support foot, yaw from base link
-            tf2::Quaternion rotation;
-            rotation.setRPY(0.0,0.0,yaw);
-            approach_frame.pose.orientation = tf2::toMsg(rotation);
-
-            // set the broadcasted transform to the position and orientation of the base footprint
-            tf.header.stamp = ros::Time::now();
-            tf.header.frame_id = "base_link";
-            tf.child_frame_id = "approach_frame";
-            tf.transform.translation.x = approach_frame.pose.position.x;
-            tf.transform.translation.y = approach_frame.pose.position.y;
-            tf.transform.translation.z = approach_frame.pose.position.z;
-            tf.transform.rotation = approach_frame.pose.orientation;
-            br.sendTransform(tf);
-
-        } catch(...){
-            continue;
+      // compute support foot
+      if (got_support_foot) {
+        if (is_left_support) {
+          support_foot = tf_left;
+          non_support_foot = tf_right;
+        } else {
+          support_foot = tf_right;
+          non_support_foot = tf_left;
         }
+      } else {
+        // check which foot is support foot (which foot is on the ground)
+        if (tf_right.transform.translation.z < tf_left.transform.translation.z) {
+          support_foot = tf_right;
+          non_support_foot = tf_left;
+        } else {
+          support_foot = tf_left;
+          non_support_foot = tf_right;
+        }
+      }
 
-        r.sleep();
+      // check with foot is in front
+      if (tf_right.transform.translation.x < tf_left.transform.translation.x) {
+        front_foot = tf_left_toe;
+        back_foot = tf_right_toe;
+      } else {
+        front_foot = tf_right_toe;
+        back_foot = tf_left_toe;
+      }
+
+      // get the position of the non support foot in the support frame, used for computing the barycenter
+      non_support_foot_in_support_foot_frame = tfBuffer.lookupTransform(support_foot.child_frame_id,
+                                                                        non_support_foot.child_frame_id,
+                                                                        support_foot.header.stamp,
+                                                                        ros::Duration(0.1));
+
+      geometry_msgs::TransformStamped support_to_base_link = tfBuffer.lookupTransform(support_foot.header.frame_id,
+                                                                                      support_foot.child_frame_id,
+                                                                                      support_foot.header.stamp);
+
+      geometry_msgs::PoseStamped approach_frame;
+      // x at front foot toes
+      approach_frame.pose.position.x = front_foot.transform.translation.x;
+      // y between feet
+      tf2::Transform center_between_foot;
+      double y = non_support_foot_in_support_foot_frame.transform.translation.y / 2;
+      center_between_foot.setOrigin({0.0, y, 0.0});
+      center_between_foot.setRotation({0, 0, 0, 1});
+      tf2::Transform support_foot_tf;
+      tf2::fromMsg(support_foot.transform, support_foot_tf);
+      center_between_foot = support_foot_tf * center_between_foot;
+      approach_frame.pose.position.y = center_between_foot.getOrigin().y();
+      // z at ground leven (support foot height)
+      approach_frame.pose.position.z = support_foot.transform.translation.z;
+
+      // roll and pitch of support foot
+      double roll, pitch, yaw;
+      tf2::Quaternion quat;
+      fromMsg(support_foot.transform.rotation, quat);
+      tf2::Matrix3x3(quat).getRPY(roll, pitch, yaw);
+      // yaw of front foot
+      yaw = tf2::getYaw(front_foot.transform.rotation);
+
+      // pitch and roll from support foot, yaw from base link
+      tf2::Quaternion rotation;
+      rotation.setRPY(0.0, 0.0, yaw);
+      approach_frame.pose.orientation = tf2::toMsg(rotation);
+
+      // set the broadcasted transform to the position and orientation of the base footprint
+      tf.header.stamp = ros::Time::now();
+      tf.header.frame_id = "base_link";
+      tf.child_frame_id = "approach_frame";
+      tf.transform.translation.x = approach_frame.pose.position.x;
+      tf.transform.translation.y = approach_frame.pose.position.y;
+      tf.transform.translation.z = approach_frame.pose.position.z;
+      tf.transform.rotation = approach_frame.pose.orientation;
+      br.sendTransform(tf);
+
+    } catch (...) {
+      continue;
     }
+
+    r.sleep();
+  }
 }
 
-void ConvenienceFramesBroadcaster::supportFootCallback(const std_msgs::Char msg)
-{
-    got_support_foot = true;
-    is_left_support = (msg.data == 'l');
+void ConvenienceFramesBroadcaster::supportFootCallback(const std_msgs::Char::ConstPtr &msg) {
+  got_support_foot = true;
+  is_left_support = (msg->data == 'l');
 }
 
-int main(int argc, char **argv)
-{
-    ros::init(argc, argv, "convenience_frames");
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "convenience_frames");
 
-    ConvenienceFramesBroadcaster b;
+  ConvenienceFramesBroadcaster b;
 }
 


### PR DESCRIPTION
This is supposed to publish additional frames which are helpful for other nodes. First frame is the "apporach_frame" which is between both feed but in x axis at the front of the robot. It can be used to approach a ball more easily

Also solves
https://github.com/bit-bots/bitbots_misc/issues/48

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] ~~Write documentation~~
- [x] Test on your machine
- [x] Test on the robot
- [x] Put into sync includes
- [ ] change GoToBall action in behavior to use this
