### PR TITLE
set_volume: always exit with exit code 0

### DIFF
--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_bringup</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 

--- a/bitbots_bringup/scripts/set_volume.sh
+++ b/bitbots_bringup/scripts/set_volume.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [[ -n $1 ]]; then
-	amixer set Master $1
+    amixer set Master $1
 else
-	amixer set Master 100%
+    amixer set Master 100%
 fi >/dev/null
+exit 0


### PR DESCRIPTION
## Proposed changes
set_volume should always return with exit code 0. Therefore on the robot without a speaker, the node does not show up in red but finishes cleanly instead.

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [x] Test on the robot

