### PR TITLE
bringup: robot state publisher frequency increase to 200

### DIFF
--- a/bitbots_bringup/launch/load_robot_description.launch
+++ b/bitbots_bringup/launch/load_robot_description.launch
@@ -72,6 +72,7 @@
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen">        
         </node>
         <param name="/simulation_active" value="false"/>
+        <param name="publish_frequency" value="200" />
     </group>
 
     <include file="$(find humanoid_base_footprint)/launch/base_footprint.launch"/>

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_bringup</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 


### PR DESCRIPTION
Increase the pulishing frequency of the robot state publisher from default 50 to 200Hz, since we are reading the joints currently with a frequency around 200Hz.

## Related issues
https://github.com/bit-bots/bitbots_misc/issues/46

## Necessary checks
- [x] Update package version
- [x] ~~Run linters~~
- [x] Run `catkin build`
- [x] ~~Write documentation~~
- [x] Test on your machine
- [ ] Test on the robot

