### PR TITLE
Basler Driver: Use master nodelet instead of standalone ones

### DIFF
--- a/bitbots_bringup/launch/basler_camera.launch
+++ b/bitbots_bringup/launch/basler_camera.launch
@@ -8,13 +8,15 @@
         <remap from="~camera_info" to="/camera_info" />
     </node>
     <group if="$(arg resize)">
-        <node pkg="nodelet" type="nodelet" args="standalone image_proc/debayer" name="debayer">
+        <node pkg="nodelet" type="nodelet" name="standalone_nodelet"  args="manager"/>
+
+        <node pkg="nodelet" type="nodelet" args="load image_proc/debayer standalone_nodelet" name="debayer">
             <remap from="image_raw"  to="/pylon_camera_node/image_raw" />
             <remap from="image_color" to="debayered_image" />
             <param name="height" value="20" />
             <param name="width" value="30" />
         </node>
-        <node pkg="nodelet" type="nodelet" args="standalone image_proc/resize" name="resizer">
+        <node pkg="nodelet" type="nodelet" args="load image_proc/resize standalone_nodelet" name="resizer">
             <remap from="/image"  to="debayered_image" />
             <remap from="~image" to="/image_resized" />
             <param name="use_scale" type="int" value="0" />


### PR DESCRIPTION
Until now the image proc nodelets ran as standalone notelets. Sorry about that. Now I added a nodelet master and registered them there.

## Proposed changes
- Add master nodelet
- Load pipeline as subprocesses of that master nodelet

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] ~Write documentation~
- [ ] ~Create issues for future work~
- [ ] ~Test on your machine~
- [x] Test on the robot
- [x] Put the PR on our Project board

