### PR TITLE
fix setting sim time active

### DIFF
--- a/bitbots_bringup/launch/load_robot_description.launch
+++ b/bitbots_bringup/launch/load_robot_description.launch
@@ -66,12 +66,14 @@
             <remap from="/joint_states" to="joint_states" />    
         </node>
         <param name="/simulation_active" value="true"/>
+        <param name="/use_sim_time" value="true"/>
     </group>
 
     <group unless="$(arg sim)">
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen">        
         </node>
         <param name="/simulation_active" value="false"/>
+        <param name="/use_sim_time" value="false"/>
     </group>
 
     <include file="$(find humanoid_base_footprint)/launch/base_footprint.launch"/>

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_bringup</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 


### PR DESCRIPTION
## Proposed changes
Small fix to correctly set use_sim_time parameter, so that simulation actually uses simulation clock and not wall clock 

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Put the PR on our Project board

