### PR TITLE
Fix for loading dynup params correctly

### DIFF
--- a/bitbots_bringup/launch/motion.launch
+++ b/bitbots_bringup/launch/motion.launch
@@ -41,6 +41,5 @@
         <arg name="use_game_settings" value="$(arg use_game_settings)"/>
     </include>
     <node if="$(arg dynamic_kick)" pkg="bitbots_dynamic_kick" name="dynamic_kick" type="KickNode" />
-    <node pkg="bitbots_dynup" name="dynup" type="DynupNode" />
-
+    <include file="$(find bitbots_dynup)/launch/dynup.launch"/>
 </launch>

--- a/bitbots_bringup/launch/motion_viz.launch
+++ b/bitbots_bringup/launch/motion_viz.launch
@@ -1,0 +1,22 @@
+<launch>
+    <arg name="sim" default="true"/>
+    <arg name="torqueless_mode" default="false" />
+
+    <!-- defines camera type -->
+    <arg name="basler" default="true" doc="Defines the robot camera type"/>
+
+    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">
+        <arg name="sim" value="$(arg sim)"/>
+        <arg name="basler" value="$(arg basler)"/>
+    </include>
+
+    <include file="$(find bitbots_bringup)/launch/motion.launch">
+        <arg name="sim" value="$(arg sim)"/>
+        <arg name="torqueless_mode" value="$(arg torqueless_mode)" />
+
+    </include>
+    <node name="motor_goals_viz_helper" pkg="bitbots_bringup" type="motor_goals_viz_helper.py" args="--all" />
+    <node name="rviz" pkg="rviz" type="rviz" output="screen" required="true"
+    args="-d $(find wolfgang_description)/config/wolfgang.rviz" />
+</launch>
+

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_bringup</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Modified the motion launchscript to execute dynup.launch instead of directly starting the node; added an rviz motion launchscript

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

