### PR TITLE
bringup: move speaker to ros control launch

### DIFF
--- a/bitbots_bringup/launch/motion.launch
+++ b/bitbots_bringup/launch/motion.launch
@@ -23,8 +23,6 @@
         <include file="$(find bitbots_buttons)/launch/buttons.launch"/>
     </group>
 
-    <include file="$(find humanoid_league_speaker)/launch/speaker.launch"/>
-
     <include file="$(find bitbots_animation_server)/launch/animation.launch">
         <arg name="use_game_settings" value="$(arg use_game_settings)"/>
     </include>

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_bringup</name>
-  <version>1.0.6</version>
+  <version>1.0.7</version>
   <description>The bitbots_bringup package is a collection of util classes used in many ROS packages from
   the Hamburg Bit-Bots.</description>
 


### PR DESCRIPTION
just a small move of launch file.
Since the speaker node is basically the interface for the audio hardware, it makes more sense to have it in the ros control launch.
Needs to be merged together with 
https://github.com/bit-bots/bitbots_lowlevel/pull/57

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

