### PR TITLE
teleop: made head movement clear

### DIFF
--- a/bitbots_teleop/package.xml
+++ b/bitbots_teleop/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_teleop</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <description>The bitbots_teleop takes messages from the joy node and converts them to messages for /cmd_vel.</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_teleop/scripts/teleop_keyboard.py
+++ b/bitbots_teleop/scripts/teleop_keyboard.py
@@ -13,17 +13,27 @@ from bitbots_msgs.msg import JointCommand
 import sys, select, termios, tty
 
 msg = """
-Reading from the keyboard and publishing to "cmd_vel"!
----------------------------
-Moving around:
-   q    w    e
-   a    s    d   
+BitBots Teleop
+--------------
+Walk around:
+    q    w    e
+    a    s    d   
 
 q/e: turn left/right
 a/d: left/rigth
 w/s: forward/back
 
-Velocities increase / decrease with multiple presses.
+Move head:
+    u    i    o
+    j    k    l
+    m    ,    .        
+
+k: zero head position
+i/,: up/down
+j/l: left/right
+u/o/m/.: combinations
+
+Controls increase / decrease with multiple presses.
 SHIFT increases with factor 10
 
 CTRL-C to quit
@@ -152,7 +162,10 @@ if __name__=="__main__":
 			sys.stdout.write("\x1b[A")
 			sys.stdout.write("\x1b[A")
 			sys.stdout.write("\x1b[A")
-			print ("x:    " + str(x) + "     \ny:    " + str(y) + "     \nturn: " + str(th) + "     ")
+			sys.stdout.write("\x1b[A")
+			sys.stdout.write("\x1b[A")
+			sys.stdout.write("\x1b[A")
+			print(f"x:    {x}          \ny:    {y}          \nturn: {th}          \n\nhead pan: {head_pan_pos:.2f}          \nhead tilt: {head_tilt_pos:.2f}          ")
 
 	except Exception as e:
 		print(e)


### PR DESCRIPTION
## Proposed changes
Fixes the interface of the teleop keyboard script. Makes it more clear how to move the head.


## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

