### PR TITLE
Only launch gazebo fakewalk odom

### DIFF
--- a/bitbots_bringup/launch/load_robot_description.launch
+++ b/bitbots_bringup/launch/load_robot_description.launch
@@ -78,6 +78,9 @@
 
     <include file="$(find humanoid_base_footprint)/launch/base_footprint.launch"/>
 
-    <include file="$(find bitbots_odometry)/launch/odometry.launch"/>
+    <group unless="$(arg use_fake_walk)">
+        <include file="$(find bitbots_odometry)/launch/odometry.launch"/>
+    </group>
+
     <include file="$(find bitbots_convenience_frames)/launch/convenience_frames.launch"/>
 </launch>


### PR DESCRIPTION
Only use one odom while using fake walking in gazebo. Otherwise, the robot jumps in odd positions.
