### PR TITLE
convenience frames: add ball_approach_frame

### DIFF
--- a/bitbots_convenience_frames/package.xml
+++ b/bitbots_convenience_frames/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_convenience_frames</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>Publishes convenience frames for the Hamburg-BitBots code base.</description>
 
   <maintainer email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</maintainer>

--- a/bitbots_convenience_frames/src/convenience_frames.cpp
+++ b/bitbots_convenience_frames/src/convenience_frames.cpp
@@ -122,6 +122,16 @@ ConvenienceFramesBroadcaster::ConvenienceFramesBroadcaster() {
       tf_.transform.translation.z = approach_frame.pose.position.z;
       tf_.transform.rotation = approach_frame.pose.orientation;
       broadcaster_.sendTransform(tf_);
+
+      // publish ball_approach_frame 10 cm in front of approach_frame
+      tf_.header.frame_id = "approach_frame";
+      tf_.child_frame_id = "ball_approach_frame";
+      tf_.transform.translation.x = 0.10;
+      tf_.transform.translation.y = 0;
+      tf_.transform.translation.z = 0;
+      tf2::Quaternion rotation_baf = tf2::Quaternion(0, 0, 0, 1);
+      tf_.transform.rotation = tf2::toMsg(rotation_baf);
+      broadcaster_.sendTransform(tf_);
     } catch (...) {
       continue;
     }


### PR DESCRIPTION
## Proposed changes
This adds a new frame (`ball_approach_frame`) that is located 10cm in front of the `approach_frame`. It will be used in the behavior to approach the ball but avoid running into it.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

