### PR TITLE
remove unnecessary remap of imu

### DIFF
--- a/bitbots_bringup/launch/simulator.launch
+++ b/bitbots_bringup/launch/simulator.launch
@@ -9,7 +9,6 @@
     <!-- remaps necessary for other parts of our software -->
     <remap from="camera/image_raw" to="camera/image_proc"/>
     <remap from="camera/camera_info" to="camera_info"/>
-    <remap from="imu" to="imu/data"/>
 
     <!-- load robot description -->
     <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
I started webots with ``roslaunch bitbots_bringup simulator.launch`` and the robot did not move. It works after removing this line.

## Necessary checks
- [ ] Update package version
- [X] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

