### PR TITLE
Fix arguments in visualization.launch

### DIFF
--- a/bitbots_bringup/launch/visualization.launch
+++ b/bitbots_bringup/launch/visualization.launch
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <launch>
     <!-- arguments -->
-    <arg name="behavior" value="true" doc="if the behavior should be started" />
-    <arg name="localization" value="false" doc="if the localization should be used" />
-    <arg name="motion" value="true" doc="if the motion should be started" />
-    <arg name="game_controller" value="false" doc="if the game controller node should be started" />
-    <arg name="use_game_settings" value="false" doc="whether game settings should be used" />
+    <arg name="behavior" default="true" doc="if the behavior should be started" />
+    <arg name="localization" default="false" doc="if the localization should be used" />
+    <arg name="motion" default="true" doc="if the motion should be started" />
+    <arg name="game_controller" default="false" doc="if the game controller node should be started" />
+    <arg name="use_game_settings" default="false" doc="whether game settings should be used" />
 
     <!-- set visualization parameter -->
     <param name="visualization_active" value="true" />


### PR DESCRIPTION
## Proposed changes
In #96, I confused `default` and `value` in `visualization.launch`, therefore the arguments could not be set on the command line.

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

