### PR TITLE
Fix CI and make packages resolvable via source rosdep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,11 @@
-@Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
 
-bitbotsPipeline([
-	new PackageDefinition("bitbots_bringup", true),
-	new PackageDefinition("bitbots_convenience_frames", true)
-] as PackageDefinition[])
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("system_monitor")))
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_time_constraint")))
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_live_tool_rqt")))
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_ceiling_cam")).withoutDocumentation().withoutPublishing())
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("bitbots_bringup")))
+pipeline.execute()

--- a/bitbots_bringup/.rdmanifest
+++ b/bitbots_bringup/.rdmanifest
@@ -1,0 +1,12 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_bringup'
+depends:
+- bitbots_docs
+exec-path: bitbots_misc-master/bitbots_bringup
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_bringup'
+uri: https://github.com/bit-bots/bitbots_misc/archive/refs/heads/master.tar.gz

--- a/bitbots_ceiling_cam/.rdmanifest
+++ b/bitbots_ceiling_cam/.rdmanifest
@@ -1,0 +1,11 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_ceiling_cam'
+depends: null
+exec-path: bitbots_misc-master/bitbots_ceiling_cam
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_ceiling_cam'
+uri: https://github.com/bit-bots/bitbots_misc/archive/refs/heads/master.tar.gz

--- a/bitbots_live_tool_rqt/.rdmanifest
+++ b/bitbots_live_tool_rqt/.rdmanifest
@@ -1,0 +1,19 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_live_tool_rqt'
+depends:
+- rospy
+- rqt_gui
+- rqt_gui_py
+- message_generation
+- std_msgs
+- rosnode
+- message_runtime
+- bitbots_docs
+exec-path: bitbots_misc-master/bitbots_live_tool_rqt
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_live_tool_rqt'
+uri: https://github.com/bit-bots/bitbots_misc/archive/refs/heads/master.tar.gz

--- a/bitbots_time_constraint/.rdmanifest
+++ b/bitbots_time_constraint/.rdmanifest
@@ -1,0 +1,15 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/bitbots_time_constraint'
+depends:
+- message_generation
+- rospy
+- bitbots_docs
+- std_msgs
+exec-path: bitbots_misc-master/bitbots_time_constraint
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/bitbots_time_constraint'
+uri: https://github.com/bit-bots/bitbots_misc/archive/refs/heads/master.tar.gz

--- a/system_monitor/.rdmanifest
+++ b/system_monitor/.rdmanifest
@@ -1,0 +1,18 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/system_monitor'
+depends:
+- message_generation
+- rospy
+- roslib
+- message_runtime
+- std_msgs
+- python3-psutil
+- bitbots_docs
+exec-path: bitbots_misc-master/system_monitor
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/system_monitor'
+uri: https://github.com/bit-bots/bitbots_misc/archive/refs/heads/master.tar.gz


### PR DESCRIPTION
## Proposed changes
As the title says, this PR reformats Jenkinsfile to the new format so that our CI passes again.
It also adds *.rdmanifest* files so that the packages can be installable through rosdep via the source package manager.

This PR only includes the packages *bitbots_bringup*, *bitbots_ceiling_cam*, *bitbtos_live_tool_rqt*, *bitbots_time_constraint* and *system_monitor* because only those packages have all their dependencies already installable in CI.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

