### PR TITLE
Add dummy imu publisher script for visualization

### DIFF
--- a/bitbots_bringup/launch/visualization.launch
+++ b/bitbots_bringup/launch/visualization.launch
@@ -13,6 +13,9 @@
     <!-- load the robot description -->
     <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" />
 
+    <!-- publish dummy imu -->
+    <node name="dummy_imu" pkg="bitbots_bringup" type="dummy_imu.py" />
+
     <!-- launch motion nodes -->
     <include if="$(arg motion)" file="$(find bitbots_bringup)/launch/motion.launch">
         <arg name="viz" value="true" />

--- a/bitbots_bringup/scripts/dummy_imu.py
+++ b/bitbots_bringup/scripts/dummy_imu.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import rospy
+from sensor_msgs.msg import Imu
+
+if __name__ == '__main__':
+    rospy.init_node('dummy_imu')
+
+    pub = rospy.Publisher('/imu/data', Imu, queue_size=1)
+
+    msg = Imu()
+    msg.header.frame_id = 'imu'
+    msg.orientation.w = 1
+
+    r = rospy.Rate(100)
+    while not rospy.is_shutdown():
+        msg.header.stamp = rospy.Time.now()
+        pub.publish(msg)
+        r.sleep()


### PR DESCRIPTION
## Proposed changes
Publishing the IMU is now required for the odometry fuser, this adds a dummy imu publisher to the visualization (the only case where odom is needed but no imu is published).

## Related issues
https://github.com/bit-bots/bitbots_motion/pull/233

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

