### PR TITLE
Make ball filter optional for debugging

### DIFF
--- a/bitbots_bringup/launch/highlevel.launch
+++ b/bitbots_bringup/launch/highlevel.launch
@@ -56,13 +56,7 @@
     </group>
     <group unless="$(arg localization)">
         <!-- simulate map frame -->
-        <group if="$(arg sim)">
-            <include file="$(find wolfgang_webots_sim)/launch/fake_localization.launch">
-            </include>
-        </group>
-        <group unless="$(arg sim)">
-            <node name="map_odom" pkg="bitbots_move_base" type="tf_map_odom.py" output="screen" />
-        </group>
+        <node name="map_odom" pkg="bitbots_move_base" type="tf_map_odom.py" output="screen" />
         <!-- publish perfect covariance -->
         <node name="localization_covariance" pkg="bitbots_localization" type="rviz_localization_sim.py" output="screen" />
     </group>

--- a/bitbots_bringup/launch/highlevel.launch
+++ b/bitbots_bringup/launch/highlevel.launch
@@ -9,6 +9,7 @@
     <arg name="transformer" default="true"/>
     <arg name="use_game_settings" default="true"/>
     <arg name="vision" default="true"/>
+    <arg name="ball_filter" default="true"/>
     <arg name="vision_debug" default="false" doc="activates the debug output of the vision pipeline"/>
 
 
@@ -35,10 +36,16 @@
         </include>
     </group>
 
+    <!-- launch teamcom -->
     <group if="$(arg teamcom)">
         <include file="$(find humanoid_league_team_communication)/launch/team_comm.launch">
             <arg name="use_game_settings" value="$(arg use_game_settings)"/>
         </include>
+    </group>
+
+    <!-- launch ball_filter -->
+    <group if="$(arg ball_filter)">
+        <include file="$(find bitbots_ball_filter)/launch/ball_filter.launch"/>
     </group>
 
     <!-- launch localization or fake localization -->
@@ -49,16 +56,19 @@
     </group>
     <group unless="$(arg localization)">
         <!-- simulate map frame -->
-        <node name="map_odom" pkg="bitbots_move_base" type="tf_map_odom.py" output="screen" />
+        <group if="$(arg sim)">
+            <include file="$(find wolfgang_webots_sim)/launch/fake_localization.launch">
+            </include>
+        </group>
+        <group unless="$(arg sim)">
+            <node name="map_odom" pkg="bitbots_move_base" type="tf_map_odom.py" output="screen" />
+        </group>
         <!-- publish perfect covariance -->
         <node name="localization_covariance" pkg="bitbots_localization" type="rviz_localization_sim.py" output="screen" />
     </group>
 
     <!-- launch pathplanning -->
     <include file="$(find bitbots_move_base)/launch/pathfinding_move_base.launch" />
-
-    <!-- launch world model-->
-    <include file="$(find bitbots_ball_filter)/launch/ball_filter.launch" />
 
     <!-- launch behavior -->
     <group if="$(arg behavior)">

--- a/bitbots_bringup/launch/simulator_teamplayer.launch
+++ b/bitbots_bringup/launch/simulator_teamplayer.launch
@@ -3,6 +3,7 @@
     <!-- set parameters -->
     <arg name="use_game_settings" default="false"/>
     <arg name="behavior" doc="start the behavior" default="true"/>
+    <arg name="ball_filter" doc="start the ball filter" default="true"/>
     <arg name="fake_walk" doc="fake the walking by using simplified physics and move the robot around on the plain field" default="false"/>
     <arg name="localization" doc="start the localization, if false publish ground truth" default="true" />
     <arg name="game_controller" doc="start the game controller" default="true"/>
@@ -20,5 +21,6 @@
         <arg name="localization" default="$(arg localization)" />
         <arg name="sim" default="true" />
         <arg name="vision_debug" default="$(arg vision_debug)"/>
+        <arg name="ball_filter" default="$(arg ball_filter)"/>
     </include>
 </launch>


### PR DESCRIPTION
## Proposed changes
This extends #112  and makes launching the ball filter optional for debugging

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

