### PR TITLE
Small fix for torque control

### DIFF
--- a/bitbots_bringup/scripts/motor_goals_viz_helper.py
+++ b/bitbots_bringup/scripts/motor_goals_viz_helper.py
@@ -83,9 +83,12 @@ class MotorVizHelper:
     def joint_command_cb(self, msg: JointCommand):
         self.joint_command_msg.header.stamp = rospy.Time.now()
         for i in range(len(msg.joint_names)):
-            name = msg.joint_names[i]
-            self.joint_command_msg.positions[JOINT_NAMES.index(name)] = msg.positions[i]
-            self.joint_command_msg.velocities[JOINT_NAMES.index(name)] = msg.velocities[i]
+            if len(msg.positions) != 0:
+                # if msg.positions is 0, torque control is probably used.
+                # there, the visualization is not implemented yet.
+                name = msg.joint_names[i]
+                self.joint_command_msg.positions[JOINT_NAMES.index(name)] = msg.positions[i]
+                self.joint_command_msg.velocities[JOINT_NAMES.index(name)] = msg.velocities[i]
 
     def animation_cb(self, msg: Animation):
         self.joint_command_msg.header.stamp = rospy.Time.now()


### PR DESCRIPTION
## Proposed changes
Small fix for torque control, only used in visualization, not in production system.
Torque control is now simply ignored in this script.

## Related issues
Required so that the script is not broken with bit-bots/bitbots_motion#298.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

