### PR TITLE
use rl walk instead of quintic walk

### DIFF
--- a/bitbots_bringup/launch/motion.launch
+++ b/bitbots_bringup/launch/motion.launch
@@ -29,9 +29,8 @@
 
     <!-- launch the walking -->
     <group if="$(arg walking)">
-        <include file="$(find bitbots_quintic_walk)/launch/quintic_walk.launch">
+        <include file="$(find bitbots_rl_motion)/launch/rl_walk.launch">
             <arg name="sim" value="$(arg sim)"/>
-            <arg name="use_game_settings" value="$(arg use_game_settings)"/>
         </include>
     </group>
 

--- a/bitbots_teleop/scripts/teleop_keyboard.py
+++ b/bitbots_teleop/scripts/teleop_keyboard.py
@@ -53,12 +53,12 @@ walkready = JointCommand(
     positions=[
         0.0,  # HeadPan
         0.0,  # HeadTilt
-        0.0,  # LShoulderPitch
+        math.radians(75.27),  # LShoulderPitch
         0.0,  # LShoulderRoll
-        0.79,  # LElbow
-        0.0,  # RShoulderPitch
+        math.radians(35.86),  # LElbow
+        math.radians(-75.58),  # RShoulderPitch
         0.0,  # RShoulderRoll
-        -0.79,  # RElbow
+        math.radians(-36.10),  # RElbow
         -0.0112,  # LHipYaw
         0.0615,  # LHipRoll
         0.4732,  # LHipPitch
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     walk_kick_pub = rospy.Publisher("kick", Bool, queue_size=1)
     joint_pub = rospy.Publisher("DynamixelController/command", JointCommand, queue_size=1)
 
-    reset_robot = rospy.ServiceProxy("/initial_pose", Empty)
+    reset_robot = rospy.ServiceProxy("/reset_pose", Empty)
     reset_ball = rospy.ServiceProxy("/reset_ball", Empty)
 
     print(msg)
@@ -328,9 +328,8 @@ if __name__ == "__main__":
             sys.stdout.write("\x1b[A")
             sys.stdout.write("\x1b[A")
             sys.stdout.write("\x1b[A")
-            sys.stdout.write("\x1b[A")
             print(
-                f"x:    {x}          \ny:    {y}          \nturn: {th}          \n\nhead pan: {head_pan_pos:.2f}          \nhead tilt: {head_tilt_pos:.2f}          ")
+                f"x:    {x}          \ny:    {y}          \nturn: {th}          \n\n")
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
## Proposed changes
Merging this pr will change usage from quintic walk to rl_walk as default in the bringup launch files.
Only merge if we want to do this.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

