### PR TITLE
fix dependency names

### DIFF
--- a/bitbots_teleop/package.xml
+++ b/bitbots_teleop/package.xml
@@ -11,11 +11,11 @@
   <license>MIT</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rospy</depend>
+  <depend>rclpy</depend>
   <depend>humanoid_league_msgs</depend>
   <depend>bitbots_msgs</depend>
   <depend>bitbots_docs</depend>
-  <depend>tf-transformations</depend>
+  <depend>tf_transformations</depend>
 
   <exec_depend>std_msgs</exec_depend>
 


### PR DESCRIPTION
Signed-off-by: Kenji Brameld <kenjibrameld@gmail.com>

## Proposed changes
Fix package.xml so rosdep works.

Here is the [tf_transformations key in rosdistro/rolling/distribution.yaml](https://github.com/ros/rosdistro/blob/809dffb01f9c3eacf663f3d212492341630943a2/rolling/distribution.yaml#L4768)


