### PR TITLE
Use source permissions for script install

### DIFF
--- a/bitbots_utils/CMakeLists.txt
+++ b/bitbots_utils/CMakeLists.txt
@@ -16,6 +16,7 @@ install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME})
 
 install(DIRECTORY scripts/
+  USE_SOURCE_PERMISSIONS
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
To keep them executable when `--symlink-install` is not used.