### PR TITLE
Bringup depend on working packages

### DIFF
--- a/bitbots_bringup/launch/highlevel.launch
+++ b/bitbots_bringup/launch/highlevel.launch
@@ -6,7 +6,7 @@
     <arg name="sim" default="false"/>
     <arg name="simple" default="false" description="Whether to use the simple behavior" />
     <arg name="teamcom" default="false"/>
-    <arg name="transformer" default="true"/>
+    <arg name="ipm" default="true"/>
     <arg name="use_game_settings" default="true"/>
     <arg name="vision" default="true"/>
     <arg name="ball_filter" default="true"/>
@@ -29,10 +29,10 @@
         </include>
     </group>
 
-    <!-- launch transformer -->
-    <group if="$(var transformer)">
-        <include file="$(find-pkg-share humanoid_league_transform)/launch/transformer.launch">
-            <arg name="use_game_settings" value="$(var use_game_settings)"/>
+    <!-- launch soccer inverse perspective mapping (ipm) -->
+    <group if="$(var ipm)">
+        <include file="$(find-pkg-share soccer_ipm)/launch/soccer_ipm.launch">
+            <arg name="sim" value="$(var sim)"/>
         </include>
     </group>
 

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -13,22 +13,20 @@
 
     <depend>bitbots_docs</depend>
 
-    <!--
     <exec_depend>bitbots_basler_camera</exec_depend>
-    <exec_depend>bitbots_body_behavior</exec_depend>
-    <exec_depend>bitbots_dynamic_kick</exec_depend>
     <exec_depend>bitbots_dynup</exec_depend>
-    <exec_depend>bitbots_hcm</exec_depend>
-    <exec_depend>bitbots_head_behavior</exec_depend>
-    <exec_depend>bitbots_localization</exec_depend>
     <exec_depend>bitbots_quintic_walk</exec_depend>
-    <exec_depend>bitbots_vision</exec_depend>
     <exec_depend>bitbots_ros_control</exec_depend>
     <exec_depend>bitbots_utils</exec_depend>
+    <exec_depend>bitbots_vision</exec_depend>
     <exec_depend>robot_state_publisher</exec_depend>
-    <exec_depend>xacro</exec_depend>
     <exec_depend>wolfgang_webots_sim</exec_depend>
-    -->
+    <exec_depend>xacro</exec_depend>
+    <!-- <exec_depend>bitbots_body_behavior</exec_depend> -->
+    <!-- <exec_depend>bitbots_dynamic_kick</exec_depend> -->
+    <!-- <exec_depend>bitbots_hcm</exec_depend> -->
+    <!-- <exec_depend>bitbots_head_behavior</exec_depend> -->
+    <!-- <exec_depend>bitbots_localization</exec_depend> -->
 
     <export>
         <bitbots_documentation>

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -14,7 +14,9 @@
     <depend>bitbots_docs</depend>
 
     <exec_depend>bitbots_basler_camera</exec_depend>
+    <exec_depend>bitbots_dynamic_kick</exec_depend>
     <exec_depend>bitbots_dynup</exec_depend>
+    <exec_depend>bitbots_localization</exec_depend>
     <exec_depend>bitbots_quintic_walk</exec_depend>
     <exec_depend>bitbots_ros_control</exec_depend>
     <exec_depend>bitbots_utils</exec_depend>
@@ -23,10 +25,8 @@
     <exec_depend>wolfgang_webots_sim</exec_depend>
     <exec_depend>xacro</exec_depend>
     <!-- <exec_depend>bitbots_body_behavior</exec_depend> -->
-    <!-- <exec_depend>bitbots_dynamic_kick</exec_depend> -->
     <!-- <exec_depend>bitbots_hcm</exec_depend> -->
     <!-- <exec_depend>bitbots_head_behavior</exec_depend> -->
-    <!-- <exec_depend>bitbots_localization</exec_depend> -->
 
     <export>
         <bitbots_documentation>

--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -14,8 +14,11 @@
     <depend>bitbots_docs</depend>
 
     <exec_depend>bitbots_basler_camera</exec_depend>
+    <exec_depend>bitbots_body_behavior</exec_depend>
     <exec_depend>bitbots_dynamic_kick</exec_depend>
     <exec_depend>bitbots_dynup</exec_depend>
+    <exec_depend>bitbots_hcm</exec_depend>
+    <exec_depend>bitbots_head_behavior</exec_depend>
     <exec_depend>bitbots_localization</exec_depend>
     <exec_depend>bitbots_quintic_walk</exec_depend>
     <exec_depend>bitbots_ros_control</exec_depend>
@@ -23,10 +26,8 @@
     <exec_depend>bitbots_vision</exec_depend>
     <exec_depend>robot_state_publisher</exec_depend>
     <exec_depend>wolfgang_webots_sim</exec_depend>
+    <exec_depend>soccer_ipm</exec_depend>
     <exec_depend>xacro</exec_depend>
-    <!-- <exec_depend>bitbots_body_behavior</exec_depend> -->
-    <!-- <exec_depend>bitbots_hcm</exec_depend> -->
-    <!-- <exec_depend>bitbots_head_behavior</exec_depend> -->
 
     <export>
         <bitbots_documentation>


### PR DESCRIPTION
## Proposed changes
This adds working dependencies back to `bitbots_bringup`.

## Related issues
Closes #151
