### PR TITLE
fix parameter parsing

### DIFF
--- a/bitbots_utils/bitbots_utils/utils.py
+++ b/bitbots_utils/bitbots_utils/utils.py
@@ -139,8 +139,6 @@ def parse_parameter_dict(*, namespace, parameter_dict):
                     namespace=full_param_name + PARAMETER_SEPARATOR_STRING,
                     parameter_dict=param_value)
         else:
-            parameter = ParameterMsg()
-            parameter.name = full_param_name
-            parameter.value = get_parameter_value(string_value=str(param_value))
-            parameters.append(parameter)
+            parameter = Parameter(name=full_param_name, value=param_value)
+            parameters.append(parameter.to_parameter_msg())
     return parameters


### PR DESCRIPTION
previously the conversion from double to string caused problems if a rather small or rather large number is converted, the scientific notation is used
e.g. 0.000001 is outputted as 1e-6. yaml 1.1 (which was used in loading parameters) requires the decimal point (i.e. 1.0e-6) this change avoids the issue by avoiding string conversion


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

