### PR TITLE
Fix: Set speaker value to 75% instead of 100%

### DIFF
--- a/bitbots_bringup/launch/motion.launch
+++ b/bitbots_bringup/launch/motion.launch
@@ -11,7 +11,7 @@
             <include file="$(find-pkg-share bitbots_ros_control)/launch/ros_control.launch">
                 <arg name="torqueless_mode" value="$(var torqueless_mode)" />
             </include>
-            <node name="set_volume" pkg="bitbots_utils" exec="set_volume.sh" args="100%" />
+            <node name="set_volume" pkg="bitbots_utils" exec="set_volume.sh" args="75%" />
         </group>
     </group>
 


### PR DESCRIPTION
## Proposed changes
Sets the speaker volume to 75% instead of 100%

## Related issues
bit-bots/humanoid_league_misc/pull/130

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

