### PR TITLE
Add missing `demo_nodes_cpp` dependency

### DIFF
--- a/bitbots_utils/package.xml
+++ b/bitbots_utils/package.xml
@@ -16,10 +16,11 @@
     <depend>bitbots_docs</depend>
 
     <exec_depend>bitbots_convenience_frames</exec_depend>
+    <exec_depend>bitbots_extrinsic_calibration</exec_depend>
     <exec_depend>bitbots_odometry</exec_depend>
+    <exec_depend>demo_nodes_cpp </exec_depend>
     <exec_depend>humanoid_base_footprint</exec_depend>
     <exec_depend>robot_state_publisher</exec_depend>
-    <exec_depend>bitbots_extrinsic_calibration</exec_depend>
     <exec_depend>wolfgang_description</exec_depend>
     <exec_depend>wolfgang_moveit_config</exec_depend>
     <exec_depend>xacro</exec_depend>


### PR DESCRIPTION
## Proposed changes
Add missing `demo_nodes_cpp` dependency

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

