### PR TITLE
Fix: Conditional dependency on wolfgang_webots_sim

### DIFF
--- a/bitbots_bringup/package.xml
+++ b/bitbots_bringup/package.xml
@@ -26,7 +26,7 @@
     <exec_depend>bitbots_utils</exec_depend>
     <exec_depend>bitbots_vision</exec_depend>
     <exec_depend>robot_state_publisher</exec_depend>
-    <exec_depend>wolfgang_webots_sim</exec_depend>
+    <exec_depend condition="$IS_ROBOT != True">wolfgang_webots_sim</exec_depend>
     <exec_depend>soccer_ipm</exec_depend>
     <exec_depend>xacro</exec_depend>
 


### PR DESCRIPTION
## Proposed changes
- Make dependency on `wolfgang_webots_sim` conditional (if we are on a robot)

## Related issues
bitbots_meta/pull/187
bitbots_meta/pull/189
bit-bots/bitbots_tools/pull/143

## Necessary checks
- [X] Put the PR on our Project board

