### PR TITLE
Use rclcpp events executor

### DIFF
--- a/bitbots_extrinsic_calibration/CMakeLists.txt
+++ b/bitbots_extrinsic_calibration/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(bitbots_docs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(rot_conv REQUIRED)
 find_package(backward_ros REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 
 include_directories(include)
 
@@ -33,7 +32,6 @@ ament_target_dependencies(extrinsic_calibration
   tf2_geometry_msgs
   tf2_ros
   rot_conv
-  irobot_events_executor
 )
 
 enable_bitbots_docs()

--- a/bitbots_extrinsic_calibration/include/extrinsic_calibration/extrinsic_calibration.h
+++ b/bitbots_extrinsic_calibration/include/extrinsic_calibration/extrinsic_calibration.h
@@ -5,7 +5,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2/utils.h>
 #include <rot_conv/rot_conv.h>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 #include <utility>
 using std::placeholders::_1;

--- a/bitbots_extrinsic_calibration/package.xml
+++ b/bitbots_extrinsic_calibration/package.xml
@@ -19,7 +19,6 @@
     <depend>tf2_ros</depend>
     <depend>rot_conv</depend>
     <depend>backward_ros</depend>
-    <depend>irobot_events_executor</depend>
 
     <export>
         <bitbots_documentation>

--- a/bitbots_extrinsic_calibration/src/extrinsic_calibration.cpp
+++ b/bitbots_extrinsic_calibration/src/extrinsic_calibration.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
   rclcpp::TimerBase::SharedPtr timer = rclcpp::create_timer(
     node, node->get_clock(), rclcpp::Duration(0, 1e7), [node]() -> void {node->step();});
 
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
   exec.spin();
   rclcpp::shutdown();


### PR DESCRIPTION
## Proposed changes
- Use rclcpp binaries for the events executor

PR because https://github.com/ros2/rclcpp/pull/2155 is merged and released.