### PR TITLE
Game settings add monitoring host

### DIFF
--- a/bitbots_utils/bitbots_utils/game_settings.py
+++ b/bitbots_utils/bitbots_utils/game_settings.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
-import sys
+
+import os
 
 import yaml
-import os
 
 
 # path to the game settings yaml and to the game setting options
-SETTING_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-                            "bitbots_utils", "config", "game_settings.yaml")
-OPTIONS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-                              "bitbots_utils","config", "game_settings_options.yaml")
+SETTING_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "bitbots_utils",
+    "config",
+    "game_settings.yaml",
+)
+OPTIONS_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "bitbots_utils",
+    "config",
+    "game_settings_options.yaml",
+)
+
+
 def provide_config(path):
     """
     reads out the yaml you are asking for with the path parameter
@@ -18,7 +28,7 @@ def provide_config(path):
     """
     if os.path.exists(path):
         try:
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 config = yaml.load(f, Loader=yaml.UnsafeLoader)
         except yaml.YAMLError as exc:
             print("Error in configuration file:", exc)
@@ -29,7 +39,9 @@ def provide_config(path):
     return config
 
 
-def ask_for_config_option(name: object, definition: object, current_value: object = None, explanation: object = None) -> object:
+def ask_for_config_option(
+    name: object, definition: object, current_value: object = None, explanation: object = None
+) -> object:
     """
     :param name: name of the config-option-value e.g. robot number
     :param definition: possible options for the value, type of input
@@ -37,21 +49,21 @@ def ask_for_config_option(name: object, definition: object, current_value: objec
     :param explanation: describes options
     :return: new chosen value for this config option, can be the old one
     """
-    print('=============== {} ==============='.format(name))
+    print("=============== {} ===============".format(name))
     if type(definition) is range:
         definition = list(definition)
     print("Options: {}".format(definition))
     print("Explanations: {}".format(explanation))
     if current_value is not None:
-        input_prompt = 'Value ({}): '.format(current_value)
+        input_prompt = "Value ({}): ".format(current_value)
     else:
-        input_prompt = 'Value: '
+        input_prompt = "Value: "
 
     value_is_valid = False
     while not value_is_valid:
         new_value = input(input_prompt).lower()
 
-        if new_value == '':
+        if new_value == "":
             if current_value is not None:
                 new_value = current_value
                 value_is_valid = True
@@ -69,48 +81,47 @@ def check_new_value(new_value: str, definition) -> bool:
     :return: true if valid, false if not
     """
 
-    
-
     definitiontype = type(definition[0])
 
     try:
-        new_value = definitiontype(new_value) # casts value to the type of
+        new_value = definitiontype(new_value)  # casts value to the type of
     except:
-        print("{} could not be converted to a {}. Are you sure it is in the right format?".format(new_value,definitiontype))
-
+        print(
+            "{} could not be converted to a {}. Are you sure it is in the right format?".format(
+                new_value, definitiontype
+            )
+        )
 
     if new_value in definition:
         return True
     else:
         # print(new_value, definition)
-        print(' {} no valid option'.format(new_value))
+        print(" {} no valid option".format(new_value))
         return False
-
 
 
 def main():
     config = provide_config(SETTING_PATH)
-    #config = config['parameter_blackboard']['ros_parameters']
-    ros_parameters = config['parameter_blackboard']['ros__parameters']
+    # config = config['parameter_blackboard']['ros_parameters']
+    ros_parameters = config["parameter_blackboard"]["ros__parameters"]
     if ros_parameters is None:
         ros_parameters = {}
-        config['parameter_blackboard']['ros__parameters'] = ros_parameters
-        
+        config["parameter_blackboard"]["ros__parameters"] = ros_parameters
+
     options = provide_config(OPTIONS_PATH)
-    
+
     for key in options.keys():
         if key in ros_parameters.keys():
-            ros_parameters[key] = ask_for_config_option(key, options[key]['options'], ros_parameters[key],
-                                                options[key]['explanation'])
+            ros_parameters[key] = ask_for_config_option(
+                key, options[key]["options"], ros_parameters[key], options[key]["explanation"]
+            )
         else:
-            value = ask_for_config_option(key, options[key]['options'], None,
-                                                options[key]['explanation'])
-            ros_parameters.update({key : value})
+            value = ask_for_config_option(key, options[key]["options"], None, options[key]["explanation"])
+            ros_parameters.update({key: value})
 
-
-    with open(SETTING_PATH, 'w') as f:
+    with open(SETTING_PATH, "w") as f:
         yaml.dump(config, f, default_flow_style=False)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bitbots_utils/config/game_settings.yaml
+++ b/bitbots_utils/config/game_settings.yaml
@@ -5,3 +5,4 @@ parameter_blackboard:
     role: defense
     team_color: 0
     team_id: 1
+    monitoring_host_ip: 0.0.0.0

--- a/bitbots_utils/config/game_settings_options.yaml
+++ b/bitbots_utils/config/game_settings_options.yaml
@@ -1,21 +1,28 @@
 ---
-# If you want to specify a range instead of a list, you will have to do it in the following way:
-# !!python/object/apply:builtins.range [10, 50, 5]
+# type will be used to cast the given input into
+# the result will then be checked against the given options for validity
+# if there are no options the given input will be accepted if it is castable
 
-# for settings which are not coverable by ranges or lists you can type "custom"
-# This will accept any input and write it to the game_settings.yaml
 bot_id:
   options: [1, 2, 3, 4, 5, 6]
+  type: int
   explanation: ""
 team_id:
   options: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 31, 32]
+  type: int
   explanation: ""
 team_color:
   options: [0, 1]
+  type: int
   explanation: "0 is blue, 1 is red"
 role:
   options: ['goalie', 'offense', 'defense', 'penalty']
+  type: str
   explanation: ""
 position_number:
   options: [0, 1, 2]
+  type: str
   explanation: "0 = center, 1 = left, 2 = right"
+monitoring_host_ip:
+  type: ipaddress.IPv4Address
+  explanation: "IP of monitoring host to send UDP messages to"

--- a/bitbots_utils/scripts/game_settings.py
+++ b/bitbots_utils/scripts/game_settings.py
@@ -8,5 +8,5 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__f
 from bitbots_utils import game_settings
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     game_settings.main()


### PR DESCRIPTION
The `game_settings.yaml` was adapted to include a `monitoring_host_ip`, so that it can be dynamically configured in other nodes (namely the udp_brige https://github.com/bit-bots/udp_bridge/pull/22).
This was done, because we have to potentially change the `monitoring_host_ip` for every game (for different competition/field ip range/laptop configurations), so it makes sense to include it in the game_settings script, which is used by the `robot_compile.py` script.

To allow for validation of both `game_settings.yaml` values with predefined options, as well as just by a predefined type, like `IPv4Address` in this case the script was also adapted.