### PR TITLE
Revert "Teamplayer: activate tools"

### DIFF
--- a/bitbots_bringup/launch/teamplayer.launch
+++ b/bitbots_bringup/launch/teamplayer.launch
@@ -10,7 +10,7 @@
     <arg name="path_planning" default="true" description="Whether the path planning should be started"/>
     <arg name="sim" default="false" description="Whether the robot is running in simulation or on real hardware" />
     <arg name="teamcom" default="false" description="Whether the team communication system should be started" />
-    <arg name="tools" default="true" description="Whether the tools should be started"/>
+    <arg name="tools" default="false" description="Whether the tools should be started"/>
     <arg name="vision" default="true" description="Whether the vision system should be started" />
     <arg name="world_model" default="true" description="Whether the world model should be started"/>
 


### PR DESCRIPTION
Reverts bit-bots/bitbots_misc#234

As the competition is over, running the tools by default is no longer needed.