### PR TITLE
Fix position_number type to int

### DIFF
--- a/bitbots_utils/config/game_settings_options.yaml
+++ b/bitbots_utils/config/game_settings_options.yaml
@@ -21,7 +21,7 @@ role:
   explanation: ""
 position_number:
   options: [0, 1, 2]
-  type: str
+  type: int
   explanation: "0 = center, 1 = left, 2 = right"
 monitoring_host_ip:
   type: ipaddress.IPv4Address


### PR DESCRIPTION
## Proposed changes
The `position_number` game setting is expected to be of type `int` but it was set to `str`.